### PR TITLE
Configurable Disk Latency function framework

### DIFF
--- a/config.go
+++ b/config.go
@@ -81,6 +81,7 @@ type ConfigStorage struct {
 	dskdurationDataChunk time.Duration
 	dskdurationFrame     time.Duration
 	diskbps              int64
+	diskLatencySim       string
 	maxDiskQueueChunks   int
 }
 
@@ -91,6 +92,7 @@ var configStorage = ConfigStorage{
 	diskMBps:      400, // MB/sec
 	maxDiskQueue:  256, // KB
 	read:          false,
+	diskLatencySim:	"latency-nil",
 }
 
 //
@@ -194,6 +196,7 @@ func PreConfig() {
 	flag.IntVar(&configStorage.numReplicas, "replicas", configStorage.numReplicas, "number of replicas")
 	flag.IntVar(&configStorage.sizeDataChunk, "chunksize", configStorage.sizeDataChunk, "chunk size (KB)")
 	flag.IntVar(&configStorage.diskMBps, "diskthroughput", configStorage.diskMBps, "disk throughput (MB/sec)")
+	flag.StringVar(&configStorage.diskLatencySim, "disklatencysim", configStorage.diskLatencySim, "disk Latency Simulator function")
 
 	flag.BoolVar(&configStorage.read, "r", configStorage.read, "read=false(100% write) | true(50/50% read/write)")
 

--- a/log.go
+++ b/log.go
@@ -105,8 +105,9 @@ func configLog(partial bool) {
                 configNetwork.sizeControlPDU, configNetwork.cmdWindowSz)
 	s4 := fmt.Sprintf("\t    {durationControlPDU:%v netdurationFrame:%v netdurationDataChunk:%v}",
 		configNetwork.durationControlPDU, configNetwork.netdurationFrame, configNetwork.netdurationDataChunk)
-	s5 := fmt.Sprintf("\t    {sizeDataChunk:%vKB dskdurationDataChunk:%v diskbps:%.1fGbps}",
-		configStorage.sizeDataChunk, configStorage.dskdurationDataChunk, float64(configStorage.diskbps)/gigb)
+	s5 := fmt.Sprintf("\t    {sizeDataChunk:%vKB dskdurationDataChunk:%v diskbps:%.1fGbps, disklatencysim:%v}",
+		configStorage.sizeDataChunk, configStorage.dskdurationDataChunk,
+		float64(configStorage.diskbps)/gigb, configStorage.diskLatencySim)
 	s6 := fmt.Sprintf("\t    {durationBidWindow:%v}", configReplicast.durationBidWindow)
 
 	if partial {

--- a/mb.go
+++ b/mb.go
@@ -209,6 +209,7 @@ func (r *serverB) rxcallbackB(ev EventInterface) int {
 
 func (r *serverB) Run() {
 	r.state = RstateRunning
+	r.disk.SetDiskLatencySimulatorByname(configStorage.diskLatencySim)
 
 	go func() {
 		for r.state == RstateRunning {
@@ -291,6 +292,7 @@ func (m *modelB) PreConfig() {
 	//       individual models need not import flag. The idea is flag should
         //       managed only in config.go
 	flag.IntVar(&configB.dummyVar, "dummy", configB.dummyVar, "Dummy Variable")
+	RegisterDiskLatencySimulator(&latencyParabola)
 }
 
 func (m *modelB) PostConfig() {


### PR DESCRIPTION
This changeset implements a framework for specifying a latency function in
the command line. This is done as an interface DiskLatencySimulator. This
interface can be implemented in each model which needs a specific form latency function.
The interface has a name and this name can be specified in command line.

disk.go implements a generic latency function called latency-nil